### PR TITLE
在weflow.config.json文件中增加outputPath配置

### DIFF
--- a/src/_tasks/dev.js
+++ b/src/_tasks/dev.js
@@ -30,6 +30,7 @@ function dev(projectPath, log, callback) {
     }
 
     let lazyDir = config.lazyDir || ['../slice', '../svg'];
+    let outputPath = config.outputPath || '/'
 
     let paths = {
         src: {
@@ -49,7 +50,7 @@ function dev(projectPath, log, callback) {
         dev: {
             dir: path.join(projectPath, './dev'),
             css: path.join(projectPath, './dev/css'),
-            html: path.join(projectPath, './dev/html'),
+            html: path.join(projectPath, `./dev${outputPath}`),
             js: path.join(projectPath, './dev/js'),
             symboltemp: path.join(projectPath, './dev/symboltemp'),
             symbol: path.join(projectPath, './dev/symbolsvg')
@@ -330,7 +331,7 @@ function dev(projectPath, log, callback) {
                 baseDir: paths.dev.dir,
                 directory: true
             },
-            startPath: "/html",
+            startPath: paths.dev.outputPath,
             port: 8080,
             reloadDelay: 0,
             timestamps: true,
@@ -425,5 +426,3 @@ function dev(projectPath, log, callback) {
 }
 
 module.exports = dev;
-
-

--- a/src/_tasks/dist.js
+++ b/src/_tasks/dist.js
@@ -56,6 +56,7 @@ function dist(projectPath, log, callback) {
     }
 
     let lazyDir = config.lazyDir || ['../slice'];
+    let outputPath = config.outputPath || '/';
 
     let postcssOption = [];
 
@@ -93,7 +94,7 @@ function dist(projectPath, log, callback) {
             css: path.join(projectPath, './tmp/css'),
             cssAll: path.join(projectPath, './tmp/css/style-*.css'),
             img: path.join(projectPath, './tmp/img'),
-            html: path.join(projectPath, './tmp/html'),
+            html: path.join(projectPath, `./tmp${outputPath}`),
             js: path.join(projectPath, './tmp/js'),
             sprite: path.join(projectPath, './tmp/sprite'),
             spriteAll: path.join(projectPath, './tmp/sprite/**/*'),
@@ -106,7 +107,7 @@ function dist(projectPath, log, callback) {
             css: path.join(projectPath, './dist/css'),
             img: path.join(projectPath, './dist/img'),
             svg: path.join(projectPath, './dist/svg'),
-            html: path.join(projectPath, './dist/html'),
+            html: path.join(projectPath, `./dist${outputPath}`),
             sprite: path.join(projectPath, './dist/sprite')
         }
     };


### PR DESCRIPTION
我们希望开发环境的目录是可以指定的，而不是完全等同于src目录。我觉得这个配置比较通用，所以私自加了下